### PR TITLE
Fix broken GH deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
As the Ubuntu 20.04 was deprecated in GitHub Actions, the deploy workflow cannot be started.

https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/

This pull request bumps the Ubuntu version to 24.04.