### PR TITLE
Add missing `contents: write` permission to deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
```
Push the commit or tag
  /usr/bin/git push origin gh-pages
  remote: Permission to transparency-dev/binary-transparency-website.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/transparency-dev/binary-transparency-website.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

https://github.com/transparency-dev/binary-transparency-website/actions/runs/21283871786/job/61260152588